### PR TITLE
Use Ruby built-in url-safe base64 methods instead of jwt package's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: ruby
 rvm:
   - 2.6
   - 2.7
+  - 3.1
 
 script: bundle exec rake spec

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -20,6 +20,7 @@
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
 
+require 'base64'
 require 'jwt'
 require 'omniauth'
 require 'openssl'
@@ -359,7 +360,7 @@ module OmniAuth
             # The key also contains other fields, such as n and e, that are
             # redundant. x5c is sufficient to verify the id token.
             if x5c = key['x5c'] and !x5c.empty?
-              OpenSSL::X509::Certificate.new(JWT::Base64.url_decode(x5c.first)).public_key
+              OpenSSL::X509::Certificate.new(Base64.urlsafe_decode64(x5c.first)).public_key
             # no x5c, so we resort to e and n
             elsif exp = key['e'] and mod = key['n']
               key = OpenSSL::PKey::RSA.new
@@ -405,7 +406,7 @@ module OmniAuth
         # This maps RS256 -> sha256, ES384 -> sha384, etc.
         algorithm = (header['alg'] || 'RS256').sub(/RS|ES|HS/, 'sha')
         full_hash = OpenSSL::Digest.new(algorithm).digest code
-        c_hash = JWT::Base64.url_encode full_hash[0..full_hash.length / 2 - 1]
+        c_hash =  Base64.urlsafe_encode64(full_hash[0..full_hash.length / 2 - 1], padding: false)
         return if c_hash == claims['c_hash']
         fail JWT::VerificationError,
              'c_hash in id token does not match auth code.'

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -406,7 +406,7 @@ module OmniAuth
         # This maps RS256 -> sha256, ES384 -> sha384, etc.
         algorithm = (header['alg'] || 'RS256').sub(/RS|ES|HS/, 'sha')
         full_hash = OpenSSL::Digest.new(algorithm).digest code
-        c_hash =  Base64.urlsafe_encode64(full_hash[0..full_hash.length / 2 - 1], padding: false)
+        c_hash = Base64.urlsafe_encode64(full_hash[0..full_hash.length / 2 - 1], padding: false)
         return if c_hash == claims['c_hash']
         fail JWT::VerificationError,
              'c_hash in id token does not match auth code.'

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.require_paths   = ['lib']
 
-  s.add_runtime_dependency 'jwt', '~> 2.2'
+  s.add_runtime_dependency 'jwt', '~> 2.4'
   s.add_runtime_dependency 'omniauth', '~> 2.0'
 
   s.add_development_dependency 'rake', '~> 13'


### PR DESCRIPTION
`jwt 2.4.1` started to use Ruby built-in base64 methods and removed its helpers. 
This package isn't working with new version and fails with `uninitialized constant JWT::Base64` error.
I did same changes similar to `jwt` package.

[#454 Use Ruby built-in url-safe base64 methods](https://github.com/jwt/ruby-jwt/pull/454)